### PR TITLE
Additional install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ $ cd metadata-extractor
 $ mvn install
 ```
 
+If you find that the build process from `mvn install` is failing because some of the tests are not passing, try this instead:
+
+```bash
+$ mvn -Dmaven.test.skip=true install
+```
+
 ## Usage
 
 ```clojure


### PR DESCRIPTION
I had some trouble installing the metadata-extractor 2.7.0-SNAPSHOT library because one of the tests was failing on my machine. 

Solved by bypassing tests altogether in the build process.
